### PR TITLE
Redo timeline function

### DIFF
--- a/compressure/main.py
+++ b/compressure/main.py
@@ -116,7 +116,6 @@ class CompressureSystem(object):
         try:
             slices = self.persistence.get_slices(fpath_source, fpath_encode, superframe_size)
         except KeyError:
-            ipdb.set_trace()
             workdir = self.persistence.init_slices_dir(fpath_encode, superframe_size)
 
             slicer = VideoSlicer(


### PR DESCRIPTION
offer more flexibility with the timeline function and make the default a negative cosine

## Rectified vs Scaled timelines
The function `main.generate_timeline_function` now supports two modes of non-negative timeline generation. `rectified` corresponds to the previous behavior (and is still the default), and `scaled` behaves slightly differently.

Basically, rectification is the process of mirroring negative components, while scaling involves doing an offset and downscaling. See the chart below for a concrete example

correction mode | input | output
---|---|---
`rectified` | `[-1, -0.5, 0, 0.5, 1, 0.5, 0]` | `[1, 0.5, 0, 0.5, 1, 0.5, 0]`
`scaled` | `[-1, -0.5, 0, 0.5, 1, 0.5, 0]`  | `[0, 0.25, 0.5, 0.75, 1, 0.75, 0.5]`